### PR TITLE
Fix isValidUntil()

### DIFF
--- a/src/SslCertificate.php
+++ b/src/SslCertificate.php
@@ -280,7 +280,7 @@ class SslCertificate
 
     public function isValidUntil(Carbon $carbon, string $url = null): bool
     {
-        if ($this->expirationDate()->gt($carbon)) {
+        if ($this->expirationDate()->lt($carbon)) {
             return false;
         }
 

--- a/tests/SslCertificateTest.php
+++ b/tests/SslCertificateTest.php
@@ -157,22 +157,22 @@ class SslCertificateTest extends PHPUnit_Framework_TestCase
     {
         // Expire date of certificate is: 17/08/2016 16:50
         Carbon::setTestNow(Carbon::create('2016', '08', '10', '16', '49', '00', 'utc'));     // 10/08   16:49
-        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(2)));     // 12/08
+        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(2)));     // 12/08
 
         Carbon::setTestNow(Carbon::create('2016', '08', '10', '16', '49', '00', 'utc'));     // 10/08   16:49
-        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(8)));      // 18/08
+        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(8)));      // 18/08
 
         Carbon::setTestNow(Carbon::create('2016', '08', '16', '16', '49', '00', 'utc'));     // 16/08   16:49
-        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(1)));     // 17/08
+        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(1)));     // 17/08
 
         Carbon::setTestNow(Carbon::create('2016', '08', '16', '16', '51', '00', 'utc'));     // 16/08   16:51
-        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(1)));      // 17/08
+        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(1)));      // 17/08
 
         Carbon::setTestNow(Carbon::create('2016', '08', '17', '16', '49', '00', 'utc'));     // 17/08   16:49
-        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(1)));      // 18/08
+        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(1)));      // 18/08
 
         Carbon::setTestNow(Carbon::create('2016', '08', '17', '16', '51', '00', 'utc'));     // 17/08   16:51
-        $this->assertFalse($this->certificate->isValidUntil(Carbon::now()->addDays(1)));     // 17/08
+        $this->assertTrue($this->certificate->isValidUntil(Carbon::now()->addDays(1)));     // 17/08
     }
 
     /** @test */


### PR DESCRIPTION
Ok ... maybe I'm going crazy - but I'm sure this function is wrong?

The original tests say:

- The expiry date of certificate is 17/8/2016
- A `isValidUntil(12/8/2016)` returns false?

But surely if a certificate is dated `17/8/2016` - then it should pass `true` for a date of `12/8/2016` because the certificate is still valid at `12/8/2016`?

Or am I missing something here? I might be tired... feel free to triple check my logic here...