### PR TITLE
Test improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache:
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   matrix:
@@ -24,7 +26,7 @@ before_script:
 
 script:
   - vendor/bin/phpstan analyse -l4 src tests
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ssl-certificate",
         "security"
     ],
-    "homepage": "https://github.com/mallardduck/ssl-certificate",
+    "homepage": "https://github.com/liquidweb/ssl-certificate",
     "license": "MIT",
     "authors": [
         {
@@ -16,16 +16,16 @@
             "role": "Developer"
         }
     ],
-    "suggests" : {
+    "suggest" : {
         "ext-gmp": "This helps to speed up the phpseclib functions, highly suggested tho not required."
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-mbstring": "*",
         "ext-filter": "*",
         "ext-openssl": "*",
         "league/uri": "^5.0",
-        "nesbot/carbon": "^1.22.1",
+        "nesbot/carbon": "^2.28",
         "phpseclib/phpseclib": "^2.0.6"
     },
     "require-dev": {

--- a/tests/SslCertificateTest.php
+++ b/tests/SslCertificateTest.php
@@ -11,7 +11,7 @@ class SslCertificateTest extends TestCase
     /** @var SslCertificate */
     protected $certificate;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SslChainTest.php
+++ b/tests/SslChainTest.php
@@ -11,7 +11,7 @@ class SslChainTest extends TestCase
     /** @var SslChain */
     protected $chain;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -37,6 +37,6 @@ class UrlTest extends TestCase
     {
         $url = new Url('https://spatie.be/opensource');
 
-        $this->assertSame('46.101.151.54', $url->getIp());
+        $this->assertSame('138.197.187.74', $url->getIp());
     }
 }


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` version tests on Travis CI build.
- The default `PHPUnit` version is incorrect on Travis CI build. Using the `vendor/bin/phpunit` version instead.
- Change into `https://github.com/liquidweb/ssl-certificate` page.
- Fix typo about `suggest` block on `composer.json`.
- The package requires `php-7.1` version at least.
- Upgrade Carbon version to be `^2.28` because the `^1.x` version is deprecated now.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method is `protected`, not `public`.
- Fixing assertion about fetching `https://spatie.be/opensource` IP address.